### PR TITLE
Remove YC demo credentials from auth page

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -59,13 +59,6 @@ const AuthPage: React.FC = () => {
           <CardHeader className="text-center">
             <CardTitle className="text-2xl font-bold">Welcome to AlphaSphere</CardTitle>
             <p className="text-muted-foreground">Sign in to your account or create a new one</p>
-            <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg">
-              <p className="text-sm text-blue-600 dark:text-blue-400">
-                <strong>YC Demo Credentials:</strong><br />
-                Email: YCdemo@gmail.com<br />
-                Password: YCdemo
-              </p>
-            </div>
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="signin">


### PR DESCRIPTION
## Summary
- remove YC demo credentials note from AuthPage
- restore original auth and portfolio demo logic

## Testing
- `npm test` (fails: Unexpected token in stockDataService.test.ts)
- `npm run lint` (fails: Unexpected any in multiple files)


------
https://chatgpt.com/codex/tasks/task_b_689b2d2dbf648326827ff4837bb212c8